### PR TITLE
adding script for Hetzner Cloud API

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ GNU General Public License v3.0
 
 - [Hetzner DNS Console](https://dns.hetzner.com/)
 - [Hetzner DNS API Dokumentation](https://dns.hetzner.com/api-docs/)
+- [Hetzner Cloud API Dokumentation](https://docs.hetzner.cloud/reference/cloud)
 - [Fritz!Box Handbuch](https://avm.de/service/handbuecher/)
 
 ---

--- a/README.md
+++ b/README.md
@@ -11,19 +11,22 @@ Ein einfaches PHP-Script, das als DynDNS-Provider fungiert und Ihre aktuelle IP-
 - ✅ **Detailliertes Logging** (optional)
 - ✅ **Sicherer Token-Transfer** über Fritz!Box Kennwort-Feld
 - ✅ **Niedrige TTL** (60 Sekunden) für schnelle Updates
+- ✅ **Neu: Support für Hetzner Cloud API** (via hetzner_dyndns_cloud.php)
 
 ## 📋 Voraussetzungen
 
 - PHP 7.0+ mit cURL Unterstützung
 - Webserver (Apache, Nginx, etc.)
-- Hetzner DNS Account mit API-Zugriff
+- Hetzner DNS Account mit API-Zugriff (Alternativ: Hetzner Cloud API mit Token)
 - Domain bereits als Zone in Hetzner DNS eingerichtet
 
-## 🛠 Installation
+## 🛠 Installation (Hetzner DNS API)
+
+Dieses Script verwenden Sie, wenn Sie die bisherige Hetzner DNS-API <https://dns.hetzner.com/api/v1/> verwenden.
 
 1. **Script herunterladen**
    ```bash
-   wget https://raw.githubusercontent.com/sakis-tech/hetzner-dyndns/main/hetzner_dyndns.php
+   wget https://raw.githubusercontent.com/bylexus/hetzner-dyndns/main/hetzner_dyndns.php
    ```
 
 2. **Auf Webserver hochladen**
@@ -36,6 +39,26 @@ Ein einfaches PHP-Script, das als DynDNS-Provider fungiert und Ihre aktuelle IP-
    - Erstellen Sie einen neuen Token mit **Lese- und Schreibrechten**
    - Notieren Sie sich den Token (wird nur einmal angezeigt!)
 
+## 🛠 Installation (Hetzner Cloud API)
+
+Dieses Script verwenden Sie, wenn Sie bereits die neue DNS-API der Hetzner Cloud (<https://api.hetzner.cloud/v1>) verwenden.
+
+1. **Script herunterladen**
+   ```bash
+   wget https://raw.githubusercontent.com/bylexus/hetzner-dyndns/main/hetzner_dyndns_cloud.php
+   ```
+
+2. **Auf Webserver hochladen**
+   - Script in ein Web-zugängliches Verzeichnis kopieren
+   - Stellen Sie sicher, dass PHP Schreibrechte für Log-Dateien hat
+
+3. **Hetzner Cloud API-Token erstellen**
+   - Gehen Sie zu [Hetzner Cloud Console](https://console.hetzner.com/)
+   - Navigieren Sie zu Ihrem Projekt
+   - Navigieren Sie zu "Sicherheit" > "API Tokens"
+   - Erstellen Sie einen neuen Token mit **Lese- und Schreibrechten**
+   - Notieren Sie sich den Token (wird nur einmal angezeigt!)
+
 ## ⚙️ Fritz!Box Konfiguration
 
 ### Schritt 1: DynDNS einrichten
@@ -44,6 +67,9 @@ Ein einfaches PHP-Script, das als DynDNS-Provider fungiert und Ihre aktuelle IP-
 3. **DynDNS verwenden** aktivieren
 
 ### Schritt 2: Anbieter konfigurieren
+
+**für die bisherige Hetzner DNS API:**
+
 - **DynDNS-Anbieter:** `Benutzerdefiniert`
 - **Update-URL:**
   ```
@@ -53,11 +79,38 @@ Ein einfaches PHP-Script, das als DynDNS-Provider fungiert und Ihre aktuelle IP-
 - **Benutzername:** `dummy` (beliebiger Text, da Fritz!Box ein Benutzername benötigt)
 - **Kennwort:** `Ihr_Hetzner_API_Token`
 
+**für die neue Hetzner Cloud API:**
+
+- **DynDNS-Anbieter:** `Benutzerdefiniert`
+- **Update-URL:**
+  ```
+  https://yourdomain.com/path/hetzner_dyndns_cloud.php?token=<pass>&domain=<domain>&ipv4=<ipaddr>&ipv6=<ip6addr>&log=true
+  ```
+- **Domainname:** `subdomain.yourdomain.com`
+- **Benutzername:** `dummy` (beliebiger Text, da Fritz!Box ein Benutzername benötigt)
+- **Kennwort:** `Ihr_Hetzner_API_Token`
+
+Alternativ können Sie das Cloud Token auch als Env-Variable setzen (z.B. wenn Sie das Script in einem Docker-Container betreiben):
+
+`HETZNER_CLOUD_API_TOKEN=xxxxxxxxxxxxxx`
+
+
 ### Schritt 3: IPv6 aktivieren (optional)
 Für IPv6-Unterstützung in der Update-URL `&ipv6=<ip6addr>` hinzufügen.
 
 ### ⚠️ Wichtiger Hinweis
 Die Fritz!Box benötigt zwingend einen Benutzernamen, auch wenn das Script diesen nicht verwendet. Geben Sie einfach einen beliebigen Text wie "dummy" oder "user" ein. **Das API-Token gehört ins Kennwort-Feld!**
+
+### ⚠️ Mehrere Domains
+
+Die Fritz!Box kann im Domain-Feld leider nur eine Domain konfigurieren. Wenn Sie mehrere Domains aktualisieren wollen, müssen Sie die Domains im Script-Pfad mitgeben:
+
+- **Update-URL:**
+  ```
+  https://yourdomain.com/path/hetzner_dyndns_cloud.php?token=<pass>&domain=sub1.domain.com,sub2.domain.com&ipv4=<ipaddr>&ipv6=<ip6addr>&log=true
+  ```
+- **Domainname:** `dummy.domain`: Da die Fritz!Box trotzdem ein Domainname benötigt, geben Sie auch hier ein Dummy-Wert an.
+
 
 ## 🔧 Verwendung
 
@@ -66,6 +119,7 @@ Die Fritz!Box benötigt zwingend einen Benutzernamen, auch wenn das Script diese
 | Parameter | Erforderlich | Beschreibung |
 |-----------|--------------|--------------|
 | `pass` | ✅ | Hetzner DNS API Token (Fritz!Box Kennwort) |
+| `token` | (✅) | Hetzner Cloud API Token (Fritz!Box Kennwort) |
 | `domain` | ✅ | Domain(s) zu aktualisieren (Komma-getrennt) |
 | `ipv4` | ❌ | IPv4-Adresse (automatisch von Fritz!Box) |
 | `ipv6` | ❌ | IPv6-Adresse (automatisch von Fritz!Box) |
@@ -76,8 +130,15 @@ Die Fritz!Box benötigt zwingend einen Benutzernamen, auch wenn das Script diese
 ### Beispiele
 
 **Fritz!Box Update-URL (Standard-Konfiguration):**
+
+herkömmliche DNS-API:
 ```
 https://example.com/hetzner_dyndns.php?pass=<pass>&domain=<domain>&ipv4=<ipaddr>&ipv6=<ip6addr>&log=true
+```
+
+neue Cloud-API:
+```
+https://example.com/hetzner_dyndns_cloud.php?token=<pass>&domain=<domain>&ipv4=<ipaddr>&ipv6=<ip6addr>&log=true
 ```
 *Die Platzhalter `<pass>`, `<domain>`, `<ipaddr>` etc. werden automatisch von der Fritz!Box ersetzt.*
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Dieses Script verwenden Sie, wenn Sie die bisherige Hetzner DNS-API <https://dns
 
 1. **Script herunterladen**
    ```bash
-   wget https://raw.githubusercontent.com/bylexus/hetzner-dyndns/main/hetzner_dyndns.php
+   wget https://raw.githubusercontent.com/sakis-tech/hetzner-dyndns/main/hetzner_dyndns.php
    ```
 
 2. **Auf Webserver hochladen**
@@ -45,7 +45,7 @@ Dieses Script verwenden Sie, wenn Sie bereits die neue DNS-API der Hetzner Cloud
 
 1. **Script herunterladen**
    ```bash
-   wget https://raw.githubusercontent.com/bylexus/hetzner-dyndns/main/hetzner_dyndns_cloud.php
+   wget https://raw.githubusercontent.com/sakis-tech/hetzner-dyndns/main/hetzner_dyndns_cloud.php
    ```
 
 2. **Auf Webserver hochladen**

--- a/hetzner_dyndns_cloud.php
+++ b/hetzner_dyndns_cloud.php
@@ -12,7 +12,7 @@
 //
 // Parameters:
 //   - token - Hetzner Cloud API token - required
-//   - domains to edit - comma-separated, required, e.g. "mail.alexi.ch, service.my-domain.ch". Note: The TLD is used as Zone name!
+//   - domain(s) to edit - comma-separated, required, e.g. "mail.alexi.ch, service.my-domain.ch". Note: The TLD is used as Zone name!
 //   - ipv4 - optional
 //   - ipv6 - optional
 //   - log (true/false) - optional (default: false)

--- a/hetzner_dyndns_cloud.php
+++ b/hetzner_dyndns_cloud.php
@@ -1,0 +1,240 @@
+<?php
+
+// Author: sakis-tech
+// Version: 2.0.5-hetzner-fritzbox
+// Created: 19.07.2025
+// License: GNU General Public License v3.0
+// Rewrite: by_lexus
+//
+// Description:
+//   This simple PHP script replaces a DynDNS provider and passes your current IP address to Hetzner Cloud DNS.
+//   It uses the Hetzner Cloud API under https://api.hetzner.cloud/v1/.
+//
+// Parameters:
+//   - token - Hetzner Cloud API token - required
+//   - domains to edit - comma-separated, required, e.g. "mail.alexi.ch, service.my-domain.ch". Note: The TLD is used as Zone name!
+//   - ipv4 - optional
+//   - ipv6 - optional
+//   - log (true/false) - optional (default: false)
+//
+// Env vars (to prevent parameter injection from outside):
+// - HETZNER_DYNDNS_LOGPATH: Path to a directory where logfiles are created
+//   
+//   Fritz!Box update URL:
+//   https://example.com/hetzner_dyndns.php?token=<pass>&domain=<domain>&ipv4=<ipaddr>&ipv6=<ip6addr>&log=true
+//   (Benutzername: dummy, Kennwort: Ihr Hetzner Cloud API Token)
+
+wlog("INFO", "===== Starting Hetzner DNS Script =====");
+header("Content-Type: text/plain");
+
+// API Token aus Fritz!Box Kennwort holen
+if (!isset($_GET["token"]) || empty($_GET["token"]) || !isset($_GET["domain"]) || empty($_GET["domain"])) {
+    wlog("ERROR", "API token or domain parameter missing or invalid");
+    wlog("INFO", "Available parameters: " . implode(", ", array_keys($_GET)));
+    wlog("INFO", "Script aborted");
+    exit_error(400, "API token or domain parameter missing or invalid");
+}
+
+$api_token = $_GET["token"];
+wlog("INFO", "Using API token: " . substr($api_token, 0, 8) . "..." . substr($api_token, -4));
+
+if (isset($_GET["ipv4"]) && !empty($_GET["ipv4"]) && filter_var($_GET["ipv4"], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) == true) {
+    wlog("INFO", "New IPv4: " . $_GET["ipv4"]);
+    $ipv4 = $_GET["ipv4"];
+} else {
+    wlog("INFO", "IPv4 not available or invalid, ignoring");
+    $ipv4 = false;
+}
+
+if (isset($_GET["ipv6"]) && !empty($_GET["ipv6"]) && filter_var($_GET["ipv6"], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) == true) {
+    wlog("INFO", "New IPv6: " . $_GET["ipv6"]);
+    $ipv6 = $_GET["ipv6"];
+} else {
+    wlog("INFO", "IPv6 not available or invalid, ignoring");
+    $ipv6 = false;
+}
+
+if (!$ipv4 && !$ipv6) {
+    wlog("ERROR", "Neither IPv4 nor IPv6 available. Probably the parameters are missing in the update URL.");
+    wlog("INFO", "Script aborted");
+    exit_error(400, "Neither IPv4 nor IPv6 available. Probably the parameters are missing in the update URL.");
+}
+
+
+
+// Test Hetzner DNS API authentication
+$auth_test = hetzner_curl("zones", $api_token);
+if (!isset($auth_test["zones"])) {
+    wlog("ERROR", "Hetzner DNS authentication failed. Token: " . substr($api_token, 0, 8) . "...");
+    if (isset($auth_test["message"])) {
+        wlog("ERROR", "API Response: " . $auth_test["message"]);
+    }
+    wlog("INFO", "Script aborted");
+    exit_error(401, "Hetzner DNS authentication failed");
+} else {
+    wlog("INFO", "Hetzner DNS authentication successful");
+}
+
+
+
+wlog("INFO", "Found records to set: " . $_GET["domain"]);
+$domains = explode(", ", $_GET["domain"]);
+$result = "success";
+
+
+foreach ($domains as $domain) {
+    $domain = trim($domain);
+    wlog("INFO", "Processing domain: " . $domain);
+
+    // Extract zone name from domain
+    $domain_parts = explode(".", $domain);
+    $zone_name = implode(".", array_slice($domain_parts, -2)); // Get last two parts (domain.tld)
+    $subdomain = implode(".", array_slice($domain_parts, 0, count($domain_parts) - 2)); // Get parts before domain.tld
+
+    // Find zone ID
+    $zones = hetzner_curl("zones?name=" . $zone_name, $api_token);
+    if (!isset($zones["zones"]) || count($zones["zones"]) == 0) {
+        wlog("ERROR", "Could not find zone for domain '" . $domain . "'");
+        $result = "failure";
+        continue;
+    }
+
+    $zone_id = $zones["zones"][0]["id"];
+    wlog("INFO", "Found zone ID: " . $zone_id . " for " . $zone_name);
+
+    // -------------- IPv4 ----------------------------
+    if (!empty($ipv4)) {
+        // Get Resource Record Set (RRSet) for IPv4 entry:
+        $res = hetzner_curl("zones/{$zone_id}/rrsets/{$subdomain}/A", $api_token);
+        wlog("DEBUG", "Response: " . print_r($res, true));
+        if (!isset($res["rrset"]['id'])) {
+            wlog("INFO", "Could not find RRSet {$subdomain}:A in zone {$zone_name}, try to create one");
+            $res = hetzner_curl(
+                "zones/{$zone_id}/rrsets",
+                $api_token,
+                [
+                    'name' => "{$subdomain}",
+                    'type' => 'A',
+                    'ttl' => 3600,
+                    'records' => [
+                        [
+                            'value' => "{$ipv4}",
+                            'comment' => 'Auto-set by ' . basename(__FILE__)
+                        ]
+                    ]
+                ],
+                'POST'
+            );
+            wlog("DEBUG", "Response: " . print_r($res, true));
+            if (!isset($res["rrset"]['id'])) {
+                wlog("ERROR", "Could not create zone for domain '" . $domain . "'. Error was: " . print_r($res, true));
+                $result = "failure";
+                continue;
+            }
+            $rrset4 = $res['rrset'];
+            $rrset4Id = $rrset4['id'];
+        } else {
+            $rrset4 = $res['rrset'];
+            $rrset4Id = $rrset4['id'];
+            wlog("INFO", "Found RRSet {$rrset4Id} for {$subdomain}:A in zone {$zone_name}.");
+        }
+        wlog("INFO", "Done with IPv4 entry for {$domain}: " . $rrset4["type"] . " " . $rrset4["name"] . " -> " . $rrset4["records"][0]["value"]);
+    }
+
+    // -------------- IPv6 ----------------------------
+    if (!empty($ipv6)) {
+        // Get Resource Record Set (RRSet) for IPv6 entry:
+        $res = hetzner_curl("zones/{$zone_id}/rrsets/{$subdomain}/AAAA", $api_token);
+        wlog("DEBUG", "Response: " . print_r($res, true));
+        if (!isset($res["rrset"]['id'])) {
+            wlog("INFO", "Could not find RRSet {$subdomain}:AAAA in zone {$zone_name}, try to create one");
+            $res = hetzner_curl(
+                "zones/{$zone_id}/rrsets",
+                $api_token,
+                [
+                    'name' => "{$subdomain}",
+                    'type' => 'AAAA',
+                    'ttl' => 3600,
+                    'records' => [
+                        [
+                            'value' => "{$ipv6}",
+                            'comment' => 'Auto-set by ' . basename(__FILE__)
+                        ]
+                    ]
+                ],
+                'POST'
+            );
+            wlog("DEBUG", "Response: " . print_r($res, true));
+            if (!isset($res["rrset"]['id'])) {
+                wlog("ERROR", "Could not create zone for domain '" . $domain . "'. Error was: " . print_r($res, true));
+                $result = "failure";
+                continue;
+            }
+            $rrset6 = $res['rrset'];
+            $rrset6Id = $rrset6['id'];
+        } else {
+            $rrset6 = $res['rrset'];
+            $rrset6Id = $rrset6['id'];
+            wlog("INFO", "Found RRSet {$rrset6Id} for {$subdomain}:A in zone {$zone_name}.");
+        }
+        wlog("INFO", "Done with IPv6 entry for {$domain}: " . $rrset6["type"] . " " . $rrset6["name"] . " -> " . $rrset6["records"][0]["value"]);
+    }
+}
+
+echo "Result: $result";
+wlog("INFO", "===== Script completed =====");
+exit();
+
+function hetzner_curl($endpoint, $api_token, $data = null, $method = "GET") {
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_URL, "https://api.hetzner.cloud/v1/" . $endpoint);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        'Authorization: Bearer ' . $api_token,
+        'Content-Type: application/json'
+    ));
+
+    if (in_array($method, ['POST', 'PUT'])) {
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+        if ($data) {
+            $json_data = json_encode($data);
+            wlog("DEBUG", "JSON POST data: " . $json_data);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $json_data);
+        }
+    }
+
+    $response = curl_exec($ch);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($http_code >= 400) {
+        wlog("ERROR", "HTTP Error " . $http_code . ": " . $response);
+        return json_decode($response, true); // Return error for debugging
+    }
+
+    return json_decode($response, true);
+}
+
+function wlog($level, $msg) {
+    // Logging nur wenn explizit auf "true" gesetzt
+    if (!isset($_GET["log"]) || $_GET["log"] !== "true") return;
+
+    $domains = explode(",", $_GET["domain"] ?? '');
+    $log_path = getenv('HETZNER_DYNDNS_LOGPATH') ?: ('.' . DIRECTORY_SEPARATOR);
+    $log_file = "{$log_path}log-hetzner-" . trim($domains[0]) . ".txt";
+    $log_entry = date("Y-m-d H:i:s") . " - " . $level . " - " . $msg . "\n";
+    // to file:
+    file_put_contents($log_file, $log_entry, FILE_APPEND | LOCK_EX);
+    // and to stdout:
+    file_put_contents('php://stdout', $log_entry, FILE_APPEND | LOCK_EX);
+}
+
+function exit_error($error_code, $msg) {
+    http_response_code($error_code);
+    echo $msg;
+    exit();
+}

--- a/hetzner_dyndns_cloud.php
+++ b/hetzner_dyndns_cloud.php
@@ -116,7 +116,7 @@ foreach ($domains as $domain) {
                 [
                     'name' => "{$subdomain}",
                     'type' => 'A',
-                    'ttl' => 3600,
+                    'ttl' => 60,
                     'records' => [
                         [
                             'value' => "{$ipv4}",
@@ -138,6 +138,20 @@ foreach ($domains as $domain) {
             $rrset4 = $res['rrset'];
             $rrset4Id = $rrset4['id'];
             wlog("INFO", "Found RRSet {$rrset4Id} for {$subdomain}:A in zone {$zone_name}, updating");
+            wlog("INFO", "Updating TTL");
+            $res = hetzner_curl(
+                "zones/{$zone_id}/rrsets/{$subdomain}/A/actions/change_ttl",
+                $api_token,
+                ['ttl' => 60],
+                'POST'
+            );
+            wlog("DEBUG", "Response: " . print_r($res, true));
+            if (!isset($res["action"]['id']) || !empty($res['action']['error'])) {
+                wlog("ERROR", "Could not update TTL for domain '" . $domain . "'. Error was: " . print_r($res, true));
+                $result = "failure";
+                continue;
+            }
+            wlog("INFO", "Updating IPv4");
             $res = hetzner_curl(
                 "zones/{$zone_id}/rrsets/{$subdomain}/A/actions/set_records",
                 $api_token,
@@ -153,7 +167,7 @@ foreach ($domains as $domain) {
             );
             wlog("DEBUG", "Response: " . print_r($res, true));
             if (!isset($res["action"]['id']) || !empty($res['action']['error'])) {
-                wlog("ERROR", "Could not update zone for domain '" . $domain . "'. Error was: " . print_r($res, true));
+                wlog("ERROR", "Could not update IP for domain '" . $domain . "'. Error was: " . print_r($res, true));
                 $result = "failure";
                 continue;
             }
@@ -174,7 +188,7 @@ foreach ($domains as $domain) {
                 [
                     'name' => "{$subdomain}",
                     'type' => 'AAAA',
-                    'ttl' => 3600,
+                    'ttl' => 60,
                     'records' => [
                         [
                             'value' => "{$ipv6}",
@@ -196,6 +210,20 @@ foreach ($domains as $domain) {
             $rrset6 = $res['rrset'];
             $rrset6Id = $rrset6['id'];
             wlog("INFO", "Found RRSet {$rrset6Id} for {$subdomain}:A in zone {$zone_name}.");
+            wlog("INFO", "Updating TTL");
+            $res = hetzner_curl(
+                "zones/{$zone_id}/rrsets/{$subdomain}/AAAA/actions/change_ttl",
+                $api_token,
+                ['ttl' => 60],
+                'POST'
+            );
+            wlog("DEBUG", "Response: " . print_r($res, true));
+            if (!isset($res["action"]['id']) || !empty($res['action']['error'])) {
+                wlog("ERROR", "Could not update TTL for domain '" . $domain . "'. Error was: " . print_r($res, true));
+                $result = "failure";
+                continue;
+            }
+            wlog("INFO", "Updating IPv6");
             $res = hetzner_curl(
                 "zones/{$zone_id}/rrsets/{$subdomain}/AAAA/actions/set_records",
                 $api_token,
@@ -211,7 +239,7 @@ foreach ($domains as $domain) {
             );
             wlog("DEBUG", "Response: " . print_r($res, true));
             if (!isset($res["action"]['id']) || !empty($res['action']['error'])) {
-                wlog("ERROR", "Could not update zone for domain '" . $domain . "'. Error was: " . print_r($res, true));
+                wlog("ERROR", "Could not update IP for domain '" . $domain . "'. Error was: " . print_r($res, true));
                 $result = "failure";
                 continue;
             }

--- a/hetzner_dyndns_cloud.php
+++ b/hetzner_dyndns_cloud.php
@@ -18,7 +18,8 @@
 //   - log (true/false) - optional (default: false)
 //
 // Env vars (to prevent parameter injection from outside):
-// - HETZNER_DYNDNS_LOGPATH: Path to a directory where logfiles are created
+// - HETZNER_DYNDNS_LOGPATH : Path to a directory where logfiles are created
+// - HETZNER_CLOUD_API_TOKEN:  Hetzner Cloud API-key, if not provided via URL (for safety reasons)
 //   
 //   Fritz!Box update URL:
 //   https://example.com/hetzner_dyndns.php?token=<pass>&domain=<domain>&ipv4=<ipaddr>&ipv6=<ip6addr>&log=true
@@ -28,14 +29,14 @@ wlog("INFO", "===== Starting Hetzner DNS Script =====");
 header("Content-Type: text/plain");
 
 // API Token aus Fritz!Box Kennwort holen
-if (!isset($_GET["token"]) || empty($_GET["token"]) || !isset($_GET["domain"]) || empty($_GET["domain"])) {
+$api_token = getenv('HETZNER_CLOUD_API_TOKEN') ?: ($_GET['token'] ?? null);
+if (empty($api_token) || !isset($_GET["domain"]) || empty($_GET["domain"])) {
     wlog("ERROR", "API token or domain parameter missing or invalid");
     wlog("INFO", "Available parameters: " . implode(", ", array_keys($_GET)));
     wlog("INFO", "Script aborted");
     exit_error(400, "API token or domain parameter missing or invalid");
 }
 
-$api_token = $_GET["token"];
 wlog("INFO", "Using API token: " . substr($api_token, 0, 8) . "..." . substr($api_token, -4));
 
 if (isset($_GET["ipv4"]) && !empty($_GET["ipv4"]) && filter_var($_GET["ipv4"], FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) == true) {


### PR DESCRIPTION
Maybe you will find this useful, so I contribute this piece back:

I have added a (separate) script (`hetzner_dyndns_cloud.php`) to support the Hetzner Cloud API (<https://api.hetzner.cloud/v1/>).

It does the same as the original hetzner_dyndns.php script, but uses the Cloud API instead: I'm using it for managing dynamic IPv4 on my Hetzner Cloud VPS.

I also adapted the readme accordingly, to include the 2nd script. I changed some URLs in the readme, as I have forked it to my github repo, so feel free to reject those URL's back to yours.

The usage / parameter names are slightly different, as the syntax / wording of the Cloud API differs (e.g. instead of "pass", use "token").

Please don't hesitate to come back for any questions / suggestions.